### PR TITLE
Rename configuration attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This extension helps developers to integrate with TalkJS easily.
 
 ## Configuration
 
-1. Setup the API ID
+1. Setup the APP ID
 2. Setup the API Secret key
 
 ## Usage
@@ -30,7 +30,7 @@ This extension helps developers to integrate with TalkJS easily.
 
 	```
 	Talkjs.configure do |config|
-      config.api_id = 'YOUR_API_ID'
+      config.app_id = 'YOUR_APP_ID'
       config.api_secret_key = 'YOUR_API_SECRET_KEY'
     end
 

--- a/lib/talkjs/v1/base.rb
+++ b/lib/talkjs/v1/base.rb
@@ -59,7 +59,7 @@ module Talkjs
       private
 
       def url
-        "#{Talkjs::URL}/v1/#{Talkjs.configuration.api_id}/#{endpoint}"
+        "#{Talkjs::URL}/v1/#{Talkjs.configuration.app_id}/#{endpoint}"
       end
     end
   end

--- a/lib/talkjs/v1/configuration.rb
+++ b/lib/talkjs/v1/configuration.rb
@@ -1,7 +1,7 @@
 module Talkjs
   module V1
     class Configuration
-      attr_accessor :api_endpoint, :api_id, :api_secret_key
+      attr_accessor :api_endpoint, :app_id, :api_secret_key
       attr_writer :connect_timeout, :send_timeout, :receive_timeout
 
       def initialize


### PR DESCRIPTION
Rename `api_id` to `app_id`, since this attribute identifies the project/app ID, not the API ID.

Reference: https://talkjs.com/docs/Reference/REST_API/Starting_a_conversation.html